### PR TITLE
Fixes order of linker flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ STRIP 	= $(CROSS)strip
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(BIN):	$(OBJS)
-	$(LD) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
+	$(LD) -o $@ $(OBJS) $(LIBS) $(LDFLAGS) 
 
 rec: rec.c
 	gcc -Wall -Werror rec.c -o rec


### PR DESCRIPTION
When the -lxxx flags preceed the list of object files,
I get a host of 'undefined reference to alXXX' errors.

Stackoverflow to the rescue:
http://stackoverflow.com/questions/8984408/linker-problems-in-ubuntu-11-10

Now I too can annoy my coworkers!