### PR TITLE
Make OPT_PATH_AUDIO default predefinable at build time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ CFLAGS  += -Wall -Werror
 CFLAGS	+= -O3 -g
 LDFLAGS += -g
 
+ifdef OPT_PATH_AUDIO
+ CFLAGS += -D'OPT_PATH_AUDIO=$(OPT_PATH_AUDIO)'
+endif
+
 ifdef mingw
  BIN     := $(NAME).exe
  CROSS   := i686-w64-mingw32-

--- a/main.c
+++ b/main.c
@@ -29,6 +29,9 @@
 		exit(1);		\
 	}
 
+#ifndef OPT_PATH_AUDIO
+#define OPT_PATH_AUDIO "./wav"
+#endif
 
 static void usage(char *exe);
 static void list_devices(void);
@@ -57,7 +60,7 @@ static int opt_stereo_width = 50;
 static int opt_gain = 100;
 static int opt_fallback_sound = 0;
 static const char *opt_device = NULL;
-static const char *opt_path_audio = "./wav";
+static const char *opt_path_audio = OPT_PATH_AUDIO;
 
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This is helpful for distributions that may not place the WAV files next to the binary.