### PR TITLE
Add mute mode: press ScrollLock twice to mute/unmute

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ options:
   -g GAIN   set playback gain [0..100]
   -h        show help
   -l        list available openAL audio devices
+  -n        disable "mute on twice ScrollLock" mode
   -p PATH   load .wav files from directory PATH
   -s WIDTH  set stereo width [0..100]
   -v        increase verbosity / debugging

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Model-M. The sound of each key has carefully been sampled, and is played back
 while simulating the proper distance and direction for a realistic 3D sound
 palette of pure nostalgic bliss.
 
+To temporarily silence bucklespring, for example to enter secrets, press
+ScrollLock twice (but be aware that those ScrollLock events _are_ delivered
+to the application); same to unmute.
+
 Installation
 ------------
 
@@ -100,7 +104,3 @@ properly tuning OpenAL for bucklespring.
  ````
  allow-moves = true
  ````
- 
- 
- 
-

--- a/main.c
+++ b/main.c
@@ -222,6 +222,13 @@ static double find_key_loc(int code)
 
 
 /*
+ * To silence play temporarily, press ScrollLock twice, same to unmute
+ */
+
+static int silenced = 0;
+static int silence_count = 0;
+
+/*
  * Play audio file for given keycode. Wav files are loaded on demand
  */
 
@@ -230,7 +237,23 @@ int play(int code, int press)
 	ALCenum error;
 
 	printd("scancode %d/0x%x", code, code);
-	
+
+	/* Check for silencing sequence: ScrollLock down+up+down */
+	if (code == 0x46) {
+		if (press == 0) {
+			if (silence_count == 1)
+				silence_count = 2;
+			else
+				silence_count = 0;
+		} else {
+			if (silence_count == 2)
+				silenced = !silenced;
+			else
+				silence_count = 1;
+		}
+	} else
+		silence_count = 0;
+
 	static ALuint buf[512] = { 0 };
 	static ALuint src[512] = { 0 };
 
@@ -272,7 +295,8 @@ int play(int code, int press)
 
 
 	if(src[idx] != 0 && src[idx] != SRC_INVALID) {
-		alSourcePlay(src[idx]);
+		if (!silenced)
+			alSourcePlay(src[idx]);
 		TEST_ERROR("source playing");
 	}
 
@@ -284,4 +308,3 @@ int play(int code, int press)
 /*
  * End
  */
-

--- a/main.c
+++ b/main.c
@@ -56,6 +56,7 @@ static int opt_verbose = 0;
 static int opt_stereo_width = 50;
 static int opt_gain = 100;
 static int opt_fallback_sound = 0;
+static int opt_nomute = 0;
 static const char *opt_device = NULL;
 static const char *opt_path_audio = PATH_AUDIO;
 
@@ -82,6 +83,9 @@ int main(int argc, char **argv)
 			case 'l':
 				list_devices();
 				return 0;
+			case 'n':
+				opt_nomute = 1;
+				break;
 			case 'v':
 				opt_verbose++;
 				break;
@@ -295,7 +299,7 @@ int play(int code, int press)
 
 
 	if(src[idx] != 0 && src[idx] != SRC_INVALID) {
-		if (!silenced)
+		if (!silenced || opt_nomute)
 			alSourcePlay(src[idx]);
 		TEST_ERROR("source playing");
 	}


### PR DESCRIPTION
This is especially relevant when you quickly need to disable it e.g. to take a customer phone call or, more importantly, when typing secrets. This is independent of the input method (I checked Macintosh and Windows code and the “pre-evdev” X11 maps, and actually tested it on evdev X.org), as ScrollLock is always mapped consistently.