### PR TITLE
use CC instead of LD by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,15 +34,16 @@ else
 endif
 
 OBJS    = $(subst .c,.o, $(SRC))
-CC 	:= $(CROSS)gcc
-LD 	:= $(CROSS)gcc
+CC 	?= $(CROSS)gcc
+LD 	?= $(CROSS)gcc
+CCLD 	?= $(CC)
 STRIP 	= $(CROSS)strip
 
 %.o: %.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 $(BIN):	$(OBJS)
-	$(LD) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
+	$(CCLD) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
 
 dist:
 	mkdir -p $(NAME)-$(VERSION)


### PR DESCRIPTION
This fixes linker issues introduced by https://github.com/zevv/bucklespring/commit/a09918f621b3e92e09206aaf4a8d6061e77a9d38 (https://github.com/zevv/bucklespring/pull/27) and reverts https://github.com/zevv/bucklespring/commit/223067afc032aace45d94846342a3f9faa34aa99.

I tested this PR with:

  - CC=gcc
  - CC=clang
  - CC=clang CCLD=gcc
  - CC=gcc CCLD=clang
  - CFLAGS="-O2" LDFLAGS="-O1"

And everything works as expected.

I hope that I got it right this time and sorry about the issues from the previous PR.