### PR TITLE
Add a  array to configure mid row location and solve stereo issues

### DIFF
--- a/main.c
+++ b/main.c
@@ -53,6 +53,18 @@ static int keyloc[][32] = {
 	{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x69, 0x6c, 0x6a, -1 },
 };
 
+/* 
+ * Horizontal position on keyboard of the pragmatic center of the row, since keys come in different sizes and shapes
+ */
+static double midloc[] = {
+	7.5,
+	7.5,
+	7.5,
+	6.5,
+	6.5,
+	6.5,
+	4.5,
+};
 
 static int opt_verbose = 0;
 static int opt_stereo_width = 50;
@@ -222,7 +234,7 @@ static double find_key_loc(int code)
 			if(keyloc[row][col] == -1) break;
 		}
 		if(keycol) {
-			return -1 + 2.0 * (double) (keycol-1) / (col-1);
+			return ((double) keycol-midloc[row])/(col-midloc[row]);
 		}
 	}
 	return 0;


### PR DESCRIPTION
Some rows are longer than others (the one above the home row for instance) and some keys will be played on the wrong side of the stereo: UIO especially, since their line is augmented with end, page down, etc.
This can be quite annoying with a large value of `-s`. 

I can't see a better way than just declaring the "mid row" value for each row and then using this in the `find_key_loc` function.

Thanks!