### PR TITLE
Add support for muting on start

### DIFF
--- a/main.c
+++ b/main.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
 	int c;
 	int rv = EXIT_SUCCESS;
 
-	while( (c = getopt(argc, argv, "fhm:vd:g:lp:s:")) != EOF) {
+	while( (c = getopt(argc, argv, "Mfhm:vd:g:lp:s:")) != EOF) {
 		switch(c) {
 			case 'd':
 				opt_device = optarg;
@@ -100,6 +100,9 @@ int main(int argc, char **argv)
 				return 0;
 			case 'm':
 				opt_mute_keycode = strtol(optarg, NULL, 0);
+				break;
+			case 'M':
+				muted = !muted;
 				break;
 			case 'v':
 				opt_verbose++;
@@ -186,6 +189,7 @@ static void usage(char *exe)
 		"  -f        use a fallback sound for unknown keys\n"
 		"  -g GAIN   set playback gain [0..100]\n"
 		"  -m CODE   use CODE as mute key (default 0x46 for scroll lock)\n"
+		"  -M        start the program muted\n"
 		"  -h        show help\n"
 		"  -l        list available openAL audio devices\n"
 		"  -p PATH   load .wav files from directory PATH\n"


### PR DESCRIPTION
With the -M option, you can start the program already muted, and unmute
it as usual.


This is mainly so that I can autostart this and unmute it when I want to
show off.