### PR TITLE
Enable build on all systems with X11.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 NAME   	:= buckle
-SRC 	:= main.c scan-linux.c scan-windows.c scan-mac.c
+SRC 	:= main.c
 VERSION	:= 1.4.0
 
 PATH_AUDIO ?= "./wav"
@@ -18,6 +18,7 @@ ifdef mingw
  LDFLAGS += -mwindows -static-libgcc -static-libstdc++
  CFLAGS  += -DALURE_STATIC_LIBRARY
  LIBS    += -Lwin32/lib -lALURE32-static -lOpenAL32 
+ SRC     += scan-windows.c
 else 
  OS := $(shell uname)
  ifeq ($(OS), Darwin)
@@ -26,10 +27,12 @@ else
   LIBS    += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs alure openal)
   CFLAGS  += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags alure openal)
   LDFLAGS += -framework ApplicationServices -framework OpenAL
+  SRC     += scan-mac.c
  else
   BIN     := $(NAME)
   LIBS    += $(shell pkg-config --libs openal alure xtst x11)
   CFLAGS  += $(shell pkg-config --cflags openal alure xtst x11)
+  SRC     += scan-x11.c
  endif
 endif
 

--- a/scan-mac.c
+++ b/scan-mac.c
@@ -1,6 +1,3 @@
-
-#ifdef __APPLE__
-
 #include <ApplicationServices/ApplicationServices.h>
 #include "buckle.h"
 
@@ -214,6 +211,3 @@ int scan(void)
 void open_console(void)
 {
 }
-
-#endif
-

--- a/scan-windows.c
+++ b/scan-windows.c
@@ -1,6 +1,3 @@
-
-#ifdef WIN32
-
 #include <windows.h>
 #include <winuser.h>
 #include <stdio.h>
@@ -77,7 +74,3 @@ void open_console()
 	*stderr = *fp;
 	setvbuf(fp, NULL, _IONBF, 0 );
 }
-
-
-#endif
-

--- a/scan-x11.c
+++ b/scan-x11.c
@@ -1,6 +1,3 @@
-
-#ifdef linux
-
 #include <stdio.h>
 
 #include <X11/XKBlib.h>
@@ -91,6 +88,3 @@ void key_pressed_cb(XPointer arg, XRecordInterceptData *d)
 void open_console(void)
 {
 }
-
-#endif
-


### PR DESCRIPTION
This renames scan-linux to scan-x11 as it is not linux-specific.

Also, the preprocessor checks in scan-* are removed and the scan-*.c
files are dynamically selected in the Makefile, as this checks thhost
and assumes X! on everything except Windows and Mac anyway.