### PR TITLE
Add systemd user service file

### DIFF
--- a/buckle.service
+++ b/buckle.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Bucklespring keyboard sound
+
+[Service]
+Type=simple
+Restart=on-failure
+ExecStart=/usr/bin/buckle -f
+
+[Install]
+WantedBy=default.target
+
+# vim: syntax=systemd


### PR DESCRIPTION
buckle.service file could be putted into /usr/lib/systemd/user/ or ~/.config/systemd/user/ directory. So user will be able to run buckle as a userspace daemon with commands:
```
$ systemctl --user enable buckle
$ systemctl --user start buckle
```