### PR TITLE
Add desktop file

### DIFF
--- a/buckle.desktop
+++ b/buckle.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+
+Type=Application
+Name=Buckle
+Comment=Bucklespring keyboard sound
+Exec=buckle -f
+Icon=input-keyboard
+StartupNotify=false
+Terminal=false
+Hidden=false
+


### PR DESCRIPTION
OK, since it clear that systemd is not a way to start buckler, there is a buckler.desktop file. It could be putted into /etc/xdg/autostart/ or ~/.config/autostart/ directories. So buckler will start with user
session start. No addition actions needed.

The relative disadvantage compared to systemd service is that if bucklewill crash it will not started again.