### PR TITLE
fix --stereo-width option not working

### DIFF
--- a/main.c
+++ b/main.c
@@ -88,7 +88,7 @@ static const struct option long_opts[] = {
 	{ "mute-keycode",   required_argument, NULL, 'm' },
 	{ "mute",           no_argument,       NULL, 'M' },
 	{ "audio-path",     required_argument, NULL, 'p' },
-	{ "stereo-width",   required_argument, NULL, 'w' },
+	{ "stereo-width",   required_argument, NULL, 's' },
 	{ "no-click",       no_argument,       NULL, 'c' },
 	{ "verbose",        no_argument,       NULL, 'v' },
         { 0, 0, 0, 0 }


### PR DESCRIPTION
The `-s` option works as usual. There was just this typo when parsing the long form arguments, which would cause the program to dump the list of options and exit.