### PR TITLE
Add button click support with libinput/Fix issue#130 about running buckle in another directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NAME   	:= buckle
 SRC 	:= main.c
 VERSION	:= 1.5.1
 
-PATH_AUDIO ?= "./wav"
+PATH_AUDIO ?= $(shell realpath ./wav)
 
 CFLAGS	?= -O3 -g
 LDFLAGS ?= -g

--- a/scan-libinput.c
+++ b/scan-libinput.c
@@ -43,6 +43,15 @@ static void handle_key(struct libinput_event *ev)
 	play(key, state == LIBINPUT_KEY_STATE_PRESSED);
 }
 
+static void handle_click(struct libinput_event *ev)
+{
+	struct libinput_event_pointer *k = libinput_event_get_pointer_event(ev);
+	enum libinput_button_state state = libinput_event_pointer_get_button_state(k);
+	uint32_t key = 0xff;
+
+	play(key, state == LIBINPUT_BUTTON_STATE_PRESSED);
+}
+
 static void handle_events(struct libinput *li)
 {
 	struct libinput_event *ev;
@@ -54,6 +63,9 @@ static void handle_events(struct libinput *li)
 		switch(libinput_event_get_type(ev)) {
 			case LIBINPUT_EVENT_KEYBOARD_KEY:
 				handle_key(ev);
+				break;
+			case LIBINPUT_EVENT_POINTER_BUTTON:
+				handle_click(ev);
 				break;
 			default:
 				break;


### PR DESCRIPTION
- Add button click support with libinput by adding a function to handle libinput pointer click event and update the switch-case in handle_events. I installed buckle and noticed that button clicks didn't trigger any sound with libinput, so I took a look at the code and fixed it.
- Fix [issue#130](https://github.com/zevv/bucklespring/issues/130) about running buckle in another directory by changing PATH_AUDIO variable in Makefile so that it can be run from any directory.