### PR TITLE
macOS: drop unmapped scancodes and normalize -p trailing slash

### DIFF
--- a/main.c
+++ b/main.c
@@ -127,9 +127,13 @@ int main(int argc, char **argv)
 			case 'M':
 				muted = !muted;
 				break;
-			case 'p':
+			case 'p': {
+				size_t len = strlen(optarg);
+				if (len > 1 && optarg[len - 1] == '/')
+					optarg[len - 1] = '\0';
 				opt_path_audio = optarg;
 				break;
+			}
 			case 's':
 				opt_stereo_width = atoi(optarg);
 				break;
@@ -321,6 +325,9 @@ int play(int code, int press)
 	ALCenum error;
 
 	printd("scancode %d/0x%x", code, code);
+
+	/* Scanner couldn't map this physical key (e.g. Fn/Globe on mac) — drop silently. */
+	if (code == 0) return 0;
 
 	if (code == 0xff && opt_no_click) return 0;
 


### PR DESCRIPTION
## Summary

Fixes a spurious stderr error when using a custom sound pack on macOS:

```
Error opening audio file "./wav-klack/Oreo//00-0.wav": Failed to open file
```

Two independent issues combined to produce that message; both fixed in `main.c`:

- **Unmapped scancode `0` leaks from the mac scanner.** `scan-mac.m`'s `mactoset1[]` table contains ~16 explicit `0` entries for Mac keycodes with no PC set-1 equivalent (Fn/Globe, power, various numpad/extended gaps). Pressing one of those keys forwards `code = 0` straight to `play()`, which then tries to load a nonexistent `00-<press>.wav`. The baseline `wav/` happens not to ship that file either, but users only notice once they run with `-p` because the error surfaces through alure. Fix: early `return 0` in `play()` when `code == 0` — scanner-agnostic, so it also covers any future unmapped path from the x11/libinput/windows scanners.

- **Trailing slash in `-p` argument produces `//` in paths.** The filename builder at `main.c:358` unconditionally inserts `/`, so `-p ./wav-klack/Oreo/` becomes `./wav-klack/Oreo//00-0.wav`. Cosmetic on POSIX, but clutters error messages and verbose logs. Fix: strip one trailing `/` from `optarg` in the `-p` handler (guarded with `len > 1` so `-p /` isn't reduced to `""`).

## Why this approach

- **Not patched in `mactoset1[]`:** the unmapped keys genuinely have no PC equivalent and the Model-M baseline ships no wav for them. Silently dropping them is the correct contract.
- **Not patched in `wav_code_of()`:** that function is an explicit table for L↔R modifier sound sharing; conflating "unmapped" with "routed" would be confusing and wouldn't help the other scanners.

## Test plan

- [x] Builds clean with `-Wall -Werror` on macOS (clang, openal-soft 1.25.1 via Homebrew).
- [ ] With a custom pack + trailing slash (`sudo ./buckle -v -p ./wav-klack/Oreo/`), press the Globe/Fn key — no stderr, verbose log shows `scancode 0/0x0` but no `Loading audio file` follow-up.
- [ ] Verbose log path shows no `//`.
- [ ] Regression: normal letters, RCtrl/RAlt/RMeta (exercises `wav_code_of` remap), consumer/media keys (exercises the `0xfe` synthetic path), and double-tap ScrollLock for mute still work.

Diff is 8 lines in `main.c`.